### PR TITLE
Force replace angle brackets in generated file name

### DIFF
--- a/RemSend/AttributeSourceGenerators/Extensions/StringExtensions.cs
+++ b/RemSend/AttributeSourceGenerators/Extensions/StringExtensions.cs
@@ -25,6 +25,8 @@ public static class StringExtensions {
     public static string SanitizeFileName(this string FileName, char ReplacementChar = '_') {
         // Symbols not allowed in generated source hint names
         FileName = FileName.Replace('@', ReplacementChar);
+        FileName = FileName.Replace('<', ReplacementChar);
+        FileName = FileName.Replace('>', ReplacementChar);
         // Symbols not allowed in any file name
         return Path.GetInvalidFileNameChars().Aggregate(FileName, (String, InvalidChar) => String.Replace(InvalidChar, ReplacementChar));
     }


### PR DESCRIPTION
While using Github Actions to build my Godot project, I unexpectedly encountered a build failure. The error log indicated:

> CSC(0,0): warning CS8785: Generator 'RemAttributeSourceGenerator' failed to generate source. It will not contribute to the output and compilation errors may occur as a result. Exception was of type 'ArgumentException' with message 'The hintName 'Casino.SyncPlayerDices(System.Collections.Generic.Dictionary<int, int[]>).g' contains an invalid character '<' at position 60. (Parameter 'hintName')'.

After comparing with my local development environment, I noticed the angle brackets '<' in filenames were not automatically replaced with underscores '_' during the Github Actions process. When I manually replaced these characters, the build completed successfully.

Although Path.GetInvalidFileNameChars() on Ubuntu doesn't include angle brackets '<' in its prohibited character list, the source generation process still rejects them during filename creation. 